### PR TITLE
Update Ausland_Erasmus.tex

### DIFF
--- a/tex/artikel/Ausland_Erasmus.tex
+++ b/tex/artikel/Ausland_Erasmus.tex
@@ -41,7 +41,7 @@ Schweden beispielsweise ist in der Tat kein günstiges Land; Lebensmittel sind i
 Wenngleich die Mietpreise in Lund vergleichbar bzw.\ leicht höher liegen als in Münster, so muss man mit ca.~800\,€ im Monat kalkulieren, um locker über die Runden zu kommen.
 Falls man keine reichen Eltern hat, ist das trotzdem kein Grund, auf das Ausland zu verzichten:
 Die Förderung über das Erasmus ist eine Finanzierungsquelle, die dabei weiterhilft.
-Je nachdem, wie hoch die Kosten im Zielland sind, erhält man eine unterschiedlich hohe Unterstützung (z.\,B.\ in Schweden, welches zur teuersten Kategorie gehört, zur Zeit für ein ganzes Jahr ca.~3000\,€).
+Je nachdem, wie hoch die Kosten im Zielland sind, erhält man eine unterschiedlich hohe Unterstützung (z.\,B.\ in Schweden, welches zur teuersten Kategorie gehört, zur Zeit für ein ganzes Jahr ca.~3000\,€ bis maximal 6000\,€).
 Außerdem besteht Anspruch auf Auslands-BAföG, wobei der Satz höher liegt als beim Inlands-BAföG.
 Falls du also hier keins bekommst, ist es trotzdem möglich, dass der Aufenthalt gefördert werden kann.
 
@@ -69,7 +69,7 @@ Und entgegen aller Sorgen und Ängste, die ich hatte, kann ich wirklich jedem w�
 Falls dein Interesse geweckt wurde, kannst du auf die Informationsveranstaltung im 2.~Semester warten oder dich schon vorher bei uns in der Fachschaft bzw.\ im Internet erkundigen:
 \begin{center}
 	% URL wurde mit \href gemacht, um den Zeilenumbruch manuell einfügen zu können
-	\href{https://www.uni-muenster.de/Physik/Studieren/Auslandsstudium}{\textbf{\texttt{https://www.uni-muenster.de/Physik/\\Studieren/Auslandsstudium}}}
+	\href{https://www.uni-muenster.de/Physik/international/}{\textbf{\texttt{https://www.uni-muenster.de/\\Physik/international/}}}
 \end{center}
 
 Prof.~Kappes (\email{erasmus.physik@uni-muenster.de}), der Erasmus-Koordinator am Fachbereich Physik, ist auch sehr nett und berät jederzeit gerne zu Auslandsaufenthalten.


### PR DESCRIPTION
- Fördergrenze angepasst, da Simons Betrag lediglich die Unterste Grenze für z.B. Schweden darstellt und ein deutlich höherer Betrag möglich ist, der vllt. etwas mehr Leute ermutigt, an Erasmus teilzunehmen. Quelle: https://www.wege-ins-ausland.de/ratgeber/foerdermoeglichkeiten-fuer-auslandsaufenthalte/auslandsaufenthalt-mit-erasmus-foerderung

- Link aktualisiert